### PR TITLE
Modify CI to treat no tests as success

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,4 +25,5 @@ jobs:
       - name: Install dependencies
         run: pip install -r requirements.txt
       - name: Run tests
-        run: pytest -vv
+        run: |
+          pytest -vv || if [ $? -eq 5 ]; then echo "No tests to run — skipping"; else exit $?; fi


### PR DESCRIPTION
## Summary
- handle pytest exit code 5 in CI workflow

## Testing
- `n/a`