### PR TITLE
Add OCR fallback with tests

### DIFF
--- a/.github/workflows/tests/test_smoke.py
+++ b/.github/workflows/tests/test_smoke.py
@@ -1,2 +1,2 @@
 def test_smoke():
-  assert True
+    assert True

--- a/app.py
+++ b/app.py
@@ -1,5 +1,4 @@
 import streamlit as st
-codex/add-ocr-handling-with-loader.py
 import ollama, textwrap
 import ollama
 import textwrap

--- a/app.py
+++ b/app.py
@@ -1,10 +1,9 @@
 import re
 import textwrap
 from tempfile import NamedTemporaryFile
-from typing import Dict
 
 import streamlit as st
-from PyPDF2 import PdfReader
+import ollama
 from duckduckgo_search import DDGS
 from wordfreq import zipf_frequency
 

--- a/app.py
+++ b/app.py
@@ -1,16 +1,19 @@
 import streamlit as st
 import ollama, textwrap
-from PyPDF2 import PdfReader
 import re
 from wordfreq import zipf_frequency
 from duckduckgo_search import DDGS
+from tempfile import NamedTemporaryFile
+from loader import load_text
 
 st.title("Med-Explain 📄➡️🧠")
 
 pdf_file = st.file_uploader("Upload a medical PDF", type="pdf")
 if pdf_file:
-    reader = PdfReader(pdf_file)
-    text = " ".join(page.extract_text() or "" for page in reader.pages)[:12000]
+    with NamedTemporaryFile(delete=False, suffix=".pdf") as tmp:
+        tmp.write(pdf_file.read())
+        tmp_path = tmp.name
+    text = load_text(tmp_path)[:12000]
     # ---- Identify likely medical jargon ----------------------------------
     words = re.findall(r"[A-Za-z]{6,}", text.lower())          # 6+ letters
     counts = {}

--- a/app.py
+++ b/app.py
@@ -1,13 +1,13 @@
-import streamlit as st
-import ollama, textwrap
-import ollama
-import textwrap
-from PyPDF2 import PdfReader
-master
 import re
-from wordfreq import zipf_frequency
-from duckduckgo_search import DDGS
+import textwrap
 from tempfile import NamedTemporaryFile
+from typing import Dict
+
+import streamlit as st
+from PyPDF2 import PdfReader
+from duckduckgo_search import DDGS
+from wordfreq import zipf_frequency
+
 from loader import load_text
 
 st.title("Med-Explain 📄➡️🧠")

--- a/loader.py
+++ b/loader.py
@@ -10,9 +10,11 @@ from PIL import Image
 
 PathLike = Union[str, bytes, Path]
 
+
 def _extract_with_pypdf2(path: PathLike) -> str:
     reader = PdfReader(path)
     return " ".join(page.extract_text() or "" for page in reader.pages)
+
 
 def _extract_with_ocr(path: PathLike) -> str:
     doc = fitz.open(path)
@@ -23,6 +25,7 @@ def _extract_with_ocr(path: PathLike) -> str:
         texts.append(pytesseract.image_to_string(img))
     doc.close()
     return "\n".join(texts)
+
 
 def load_text(path: PathLike) -> str:
     text = _extract_with_pypdf2(path)

--- a/loader.py
+++ b/loader.py
@@ -1,0 +1,31 @@
+import io
+from pathlib import Path
+from typing import Union
+
+from PyPDF2 import PdfReader
+import fitz  # PyMuPDF
+import pytesseract
+from PIL import Image
+
+
+PathLike = Union[str, bytes, Path]
+
+def _extract_with_pypdf2(path: PathLike) -> str:
+    reader = PdfReader(path)
+    return " ".join(page.extract_text() or "" for page in reader.pages)
+
+def _extract_with_ocr(path: PathLike) -> str:
+    doc = fitz.open(path)
+    texts = []
+    for page in doc:
+        pix = page.get_pixmap()
+        img = Image.open(io.BytesIO(pix.tobytes("png")))
+        texts.append(pytesseract.image_to_string(img))
+    doc.close()
+    return "\n".join(texts)
+
+def load_text(path: PathLike) -> str:
+    text = _extract_with_pypdf2(path)
+    if text.strip():
+        return text
+    return _extract_with_ocr(path)

--- a/summary.py
+++ b/summary.py
@@ -9,14 +9,6 @@ import ollama
 from loader import load_text
 
 
-pdf_path = sys.argv[1]
-text = load_text(pdf_path)[:12000]
-def load_text(pdf_path: str) -> str:
-    """Extract up to 12 000 chars of text from a PDF."""
-    reader = PdfReader(pdf_path)
-    return " ".join(page.extract_text() or "" for page in reader.pages)[:12000]
-
-
 def summarize(text: str) -> str:
     prompt = (
         "Explain the following medical document in 200 words or less so a "
@@ -30,7 +22,6 @@ def summarize(text: str) -> str:
 
 
 def main(argv: Optional[List[str]] = None) -> None:
-    """Entry point for CLI usage."""
     if argv is None:
         argv = sys.argv[1:]
 
@@ -39,12 +30,12 @@ def main(argv: Optional[List[str]] = None) -> None:
         sys.exit(1)
 
     pdf_path = argv[0]
-    text = load_text(pdf_path)
+    text = load_text(pdf_path)[:12_000]
     result = summarize(text)
 
     print("\n[bold green]Summary:[/]\n")
     print(textwrap.fill(result, 80))
 
 
-if __name__ == "__main__":  # pragma: no cover – direct execution
+if __name__ == "__main__":  # pragma: no cover
     main()

--- a/summary.py
+++ b/summary.py
@@ -3,7 +3,6 @@ import textwrap
 from typing import List, Optional
 
 from rich import print
-from PyPDF2 import PdfReader
 import ollama
 
 from loader import load_text

--- a/summary.py
+++ b/summary.py
@@ -1,12 +1,11 @@
-import sys, textwrap
 import sys
 import textwrap
 from typing import List, Optional
 
-from PyPDF2 import PdfReader
-master
-import ollama
 from rich import print
+from PyPDF2 import PdfReader
+import ollama
+
 from loader import load_text
 
 
@@ -42,7 +41,6 @@ def main(argv: Optional[List[str]] = None) -> None:
     pdf_path = argv[0]
     text = load_text(pdf_path)
     result = summarize(text)
-    master
 
     print("\n[bold green]Summary:[/]\n")
     print(textwrap.fill(result, 80))

--- a/summary.py
+++ b/summary.py
@@ -1,15 +1,14 @@
 import sys, textwrap
-from PyPDF2 import PdfReader
 import ollama
 from rich import print
+from loader import load_text
 
 if len(sys.argv) != 2:
     print("[red]Usage:[/] python summary.py <file.pdf>")
     sys.exit(1)
 
 pdf_path = sys.argv[1]
-reader   = PdfReader(pdf_path)
-text     = " ".join(page.extract_text() or "" for page in reader.pages)[:12000]
+text = load_text(pdf_path)[:12000]
 
 prompt = (
     "Explain the following medical document in 200 words or less so a "

--- a/summary.py
+++ b/summary.py
@@ -1,4 +1,3 @@
-codex/add-ocr-handling-with-loader.py
 import sys, textwrap
 import sys
 import textwrap
@@ -11,7 +10,6 @@ from rich import print
 from loader import load_text
 
 
-codex/add-ocr-handling-with-loader.py
 pdf_path = sys.argv[1]
 text = load_text(pdf_path)[:12000]
 def load_text(pdf_path: str) -> str:

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -23,10 +23,10 @@ def create_empty_pdf(path):
 
 
 def create_scanned_pdf(path, text):
-    img = Image.new('RGB', (400, 200), color='white')
+    img = Image.new("RGB", (400, 200), color="white")
     draw = ImageDraw.Draw(img)
-    draw.text((50, 80), text, fill='black')
-    img_path = path.with_suffix('.png')
+    draw.text((50, 80), text, fill="black")
+    img_path = path.with_suffix(".png")
     img.save(img_path)
     doc = fitz.open()
     page = doc.new_page(width=400, height=200)

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -2,7 +2,6 @@ import os
 import sys
 import fitz
 from PIL import Image, ImageDraw
-import pytest
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 from loader import load_text

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -1,0 +1,58 @@
+import os
+import sys
+import fitz
+from PIL import Image, ImageDraw
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+from loader import load_text
+
+
+def create_pdf_with_text(path, text):
+    doc = fitz.open()
+    page = doc.new_page()
+    page.insert_text((72, 72), text)
+    doc.save(path)
+    doc.close()
+
+
+def create_empty_pdf(path):
+    doc = fitz.open()
+    doc.new_page()
+    doc.save(path)
+    doc.close()
+
+
+def create_scanned_pdf(path, text):
+    img = Image.new('RGB', (400, 200), color='white')
+    draw = ImageDraw.Draw(img)
+    draw.text((50, 80), text, fill='black')
+    img_path = path.with_suffix('.png')
+    img.save(img_path)
+    doc = fitz.open()
+    page = doc.new_page(width=400, height=200)
+    page.insert_image(page.rect, filename=img_path)
+    doc.save(path)
+    doc.close()
+    os.remove(img_path)
+
+
+def test_normal_pdf(tmp_path):
+    pdf = tmp_path / "normal.pdf"
+    create_pdf_with_text(pdf, "Hello World")
+    text = load_text(pdf)
+    assert "Hello World" in text
+
+
+def test_empty_pdf(tmp_path):
+    pdf = tmp_path / "empty.pdf"
+    create_empty_pdf(pdf)
+    text = load_text(pdf)
+    assert text.strip() == ""
+
+
+def test_scanned_pdf(tmp_path):
+    pdf = tmp_path / "scan.pdf"
+    create_scanned_pdf(pdf, "OCR Test")
+    text = load_text(pdf)
+    assert "Test" in text

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1,6 +1,7 @@
 import importlib
 import pytest
 
+
 @pytest.mark.parametrize("mod", ["app", "summary"])
 def test_import(mod):
     """Ensure key modules can be imported."""


### PR DESCRIPTION
## Summary
- introduce loader.load_text to extract text from PDFs
- use loader.load_text in command-line and web apps
- add automated tests including OCR of a scanned PDF

## Testing
- `pytest -q`