### PR TITLE
Add Docker and compose setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM python:3.11-slim
+
+# Install tesseract and other dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        tesseract-ocr \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Python requirements
+COPY requirements.txt /app/requirements.txt
+RUN pip install --no-cache-dir -r /app/requirements.txt
+
+WORKDIR /app
+COPY . /app
+
+EXPOSE 8501
+
+CMD ["streamlit", "run", "app.py", "--server.port", "8501", "--server.address", "0.0.0.0"]

--- a/README.md
+++ b/README.md
@@ -1,0 +1,45 @@
+# Med-Explain
+
+A small Streamlit application that summarizes medical PDFs with the help of an
+Ollama language model. The container image includes Tesseract for OCR and the
+`ollama` Python package so the app can interact with an Ollama server.
+
+## Requirements
+
+Docker and Docker Compose are required to build and run the project.
+
+## Build and Run
+
+The recommended way to start the application is with Docker Compose which runs
+both the Ollama server and the Streamlit app:
+
+```bash
+# Build the images and start the containers
+docker compose up --build
+```
+
+The Streamlit interface will be available at
+[http://localhost:8501](http://localhost:8501) and Ollama listens on port
+`11434` for API calls.
+
+To stop the containers press `Ctrl+C` and then run:
+
+```bash
+docker compose down
+```
+
+### Building the app image manually
+
+You can also build the Streamlit application image separately:
+
+```bash
+docker build -t med-explain .
+```
+
+Run it with:
+
+```bash
+docker run -p 8501:8501 med-explain
+```
+
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,21 @@
+version: '3.8'
+services:
+  ollama:
+    image: ollama/ollama
+    ports:
+      - "11434:11434"
+    volumes:
+      - ollama-data:/root/.ollama
+    restart: unless-stopped
+
+  app:
+    build: .
+    ports:
+      - "8501:8501"
+    environment:
+      - OLLAMA_HOST=http://ollama:11434
+    depends_on:
+      - ollama
+
+volumes:
+  ollama-data:


### PR DESCRIPTION
## Summary
- add Dockerfile with Python, Tesseract and Streamlit entrypoint
- include docker-compose.yml to run Ollama server with the app
- document build and run steps in a new README

## Testing
- `pytest -q`
- `python -m py_compile $(git ls-files '*.py')`
